### PR TITLE
typecast drawText argument to correct type

### DIFF
--- a/src/custom_editor.py
+++ b/src/custom_editor.py
@@ -62,7 +62,7 @@ class QCodeEditor(QPlainTextEdit):
             if block.isVisible() and (bottom >= event.rect().top()):
                 number = str(block_number + 1)
                 painter.setPen(Qt.black)
-                painter.drawText(0, top, self.line_number_area.width(), height, Qt.AlignRight, number)
+                painter.drawText(0, int(top), self.line_number_area.width(), height, Qt.AlignRight, number)
             block = block.next()
             top = bottom
             bottom = top + self.blockBoundingRect(block).height()


### PR DESCRIPTION
The current code crashes on my machine(Linux, Python 3.11.6):

TypeError: arguments did not match any overloaded call:
drawText(self, x: int, y: int, s: Optional[str]): argument 2 has unexpected type 'float'

The variable 'top' was the culprit, and casting it to an int fixed the error.

The simulator now runs and seems to look like it should to my eyes. A quick print of top's float value showed that it only ever took on whole integer numbers (4.0, 31.0, 58.0, 85.0, 112.0, ...), so the cast hopefully wont change any functionality.
